### PR TITLE
Some refactoring

### DIFF
--- a/cmd/cachecmd/main.go
+++ b/cmd/cachecmd/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -327,11 +328,16 @@ func cacheDir() string {
 
 // REF: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html
 func xdgCacheHome() string {
-	path := os.Getenv("XDG_CACHE_HOME")
-	if path == "" {
-		path = filepath.Join(os.Getenv("HOME"), ".cache")
+	home := ""
+	if runtime.GOOS == "windows" {
+		home = os.Getenv("USERPROFILE")
+	} else {
+		home = os.Getenv("XDG_CACHE_HOME")
+		if home == "" {
+			home = os.Getenv("HOME")
+		}
 	}
-	return path
+	return filepath.Join(home, ".cache")
 }
 
 func exitError(err error) (int, error) {

--- a/cmd/cachecmd/main.go
+++ b/cmd/cachecmd/main.go
@@ -341,16 +341,16 @@ func cacheDir() string {
 
 // REF: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html
 func xdgCacheHome() string {
-	home := ""
-	if runtime.GOOS == "windows" {
-		home = os.Getenv("USERPROFILE")
-	} else {
-		home = os.Getenv("XDG_CACHE_HOME")
-		if home == "" {
-			home = os.Getenv("HOME")
-		}
+	dir := os.Getenv("XDG_CACHE_HOME")
+	if dir != "" {
+		return dir
 	}
-	return filepath.Join(home, ".cache")
+	if runtime.GOOS == "windows" {
+		dir = os.Getenv("USERPROFILE")
+	} else {
+		dir = os.Getenv("HOME")
+	}
+	return filepath.Join(dir, ".cache")
 }
 
 func exitError(err error) (int, error) {

--- a/cmd/cachecmd/main_test.go
+++ b/cmd/cachecmd/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -159,6 +160,10 @@ func TestCacheCmd_Run_async(t *testing.T) {
 	}
 	cmd := "date"
 	args := []string{`+%N`}
+	if runtime.GOOS == "windows" {
+		cmd = "cmd"
+		args = []string{`/c`, `echo %TIME%`}
+	}
 
 	tmpdir, _ := ioutil.TempDir("", "cachecmdtest")
 	defer os.RemoveAll(tmpdir)
@@ -248,6 +253,9 @@ func prepareBinary(t *testing.T) (bin string, cleanup func(), err error) {
 		os.RemoveAll(tmpDir)
 	}
 	bin = filepath.Join(tmpDir, "cachecmd")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
 	err = exec.Command("go", "build", "-o", bin, pkg).Run()
 	return bin, cleanup, err
 }


### PR DESCRIPTION
* use path `%USERPROFILE%\.cache` on Windows
* do not return overwritten error when it is native error
* small fix test on Windows